### PR TITLE
Add JWT auth, analytics logging, Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+venv/
+*.pyc
+*.db

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,49 @@
+# URL Shortener
+
+This project provides a simple URL shortener built with FastAPI and SQLAlchemy. It now supports JWT based authentication and click analytics.
+
+## Installation
+
+```bash
+python -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Usage
+
+1. **Start the server**
+
+```bash
+uvicorn main:app --reload
+```
+
+2. **Get a token**
+
+Send a POST request to `/token` with form fields `username` and `password`. An admin user with username `admin` and password `admin` is created at startup.
+
+3. **Create a short URL**
+
+Send an authenticated POST request to `/shorten` with JSON body:
+
+```json
+{"original_url": "https://example.com"}
+```
+
+4. **Redirect**
+
+Access `/<short_code>` in the browser to be redirected.
+
+5. **View analytics**
+
+Authenticated users can request `/analytics/{short_code}` to see clicks for their own URLs. Admin users can access `/admin/analytics` to see analytics for all URLs.
+
+## Docker
+
+A simple Dockerfile is included for containerized deployments:
+
+```bash
+docker build -t url-shortener .
+docker run -p 8000:8000 url-shortener
+```
+

--- a/crud.py
+++ b/crud.py
@@ -2,13 +2,16 @@
 import random
 import string
 from sqlalchemy.orm import Session
-from models import URL
+from models import URL, User, ClickLog
+from passlib.context import CryptContext
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
 def get_url_by_code(db: Session, code: str):
     return db.query(URL).filter(URL.short_code == code).first()
 
-def get_or_create_short_url(db: Session, original_url: str) -> URL:
-    existing = db.query(URL).filter(URL.original_url == original_url).first()
+def get_or_create_short_url(db: Session, original_url: str, owner_id: int | None = None) -> URL:
+    existing = db.query(URL).filter(URL.original_url == original_url, URL.owner_id == owner_id).first()
     if existing:
         return existing
 
@@ -18,10 +21,40 @@ def get_or_create_short_url(db: Session, original_url: str) -> URL:
         if not db.query(URL).filter(URL.short_code == code).first():
             break
 
-    new_url = URL(original_url=original_url, short_code=code)
+    new_url = URL(original_url=original_url, short_code=code, owner_id=owner_id)
     db.add(new_url)
     db.commit()
     db.refresh(new_url)
     return new_url
+
+
+def log_click(db: Session, url: URL):
+    db.add(ClickLog(url_id=url.id))
+    url.clicks += 1
+    db.commit()
+
+
+def get_user_by_username(db: Session, username: str) -> User | None:
+    return db.query(User).filter(User.username == username).first()
+
+
+def create_user(db: Session, username: str, password: str, is_admin: bool = False) -> User:
+    hashed_pw = pwd_context.hash(password)
+    user = User(username=username, hashed_password=hashed_pw, is_admin=is_admin)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+def authenticate_user(db: Session, username: str, password: str) -> User | None:
+    user = get_user_by_username(db, username)
+    if user and verify_password(password, user.hashed_password):
+        return user
+    return None
 
 

--- a/main.py
+++ b/main.py
@@ -1,24 +1,34 @@
-from fastapi.staticfiles import StaticFiles
-from fastapi.responses import HTMLResponse
 import os
-from fastapi import Request
-from fastapi import FastAPI, Depends, HTTPException
+from datetime import datetime, timedelta
+
+from fastapi import FastAPI, Depends, HTTPException, Request, status
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
+from fastapi.staticfiles import StaticFiles
+from jose import JWTError, jwt
 from sqlalchemy.orm import Session
-import models, schemas, crud
-from database import SessionLocal, engine, Base
 
-Base.metadata.create_all(bind=engine)
-app = FastAPI()
-
-app.mount("/static", StaticFiles(directory="static"), name="static")
-
-@app.get("/", response_class=HTMLResponse)
-def serve_homepage():
-    with open(os.path.join("static", "index.html")) as f:
-        return f.read()
+import crud
+import models
+import schemas
+from database import Base, SessionLocal, engine
 
 
-# Dependency to get DB session
+SECRET_KEY = "change_this_secret"  # In production use env var
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = 30
+
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+
+
+def create_access_token(data: dict, expires_delta: timedelta | None = None) -> str:
+    to_encode = data.copy()
+    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES))
+    to_encode.update({"exp": expire})
+    return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+
+
 def get_db():
     db = SessionLocal()
     try:
@@ -26,35 +36,105 @@ def get_db():
     finally:
         db.close()
 
+
+def get_current_user(token: str = Depends(oauth2_scheme), db: Session = Depends(get_db)) -> models.User:
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        username: str | None = payload.get("sub")
+        if username is None:
+            raise credentials_exception
+    except JWTError:
+        raise credentials_exception
+    user = crud.get_user_by_username(db, username)
+    if user is None:
+        raise credentials_exception
+    return user
+
+
+def get_current_admin(current_user: models.User = Depends(get_current_user)) -> models.User:
+    if not current_user.is_admin:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not enough permissions")
+    return current_user
+
+
+app = FastAPI()
+app.mount("/static", StaticFiles(directory="static"), name="static")
+
+
+@app.on_event("startup")
+def startup_event():
+    Base.metadata.create_all(bind=engine)
+    db = SessionLocal()
+    if not crud.get_user_by_username(db, "admin"):
+        crud.create_user(db, "admin", "admin", is_admin=True)
+    db.close()
+
+
+@app.get("/", response_class=HTMLResponse)
+def serve_homepage():
+    with open(os.path.join("static", "index.html")) as f:
+        return f.read()
+
+
+@app.post("/token", response_model=schemas.Token)
+def login_for_access_token(form_data: OAuth2PasswordRequestForm = Depends(), db: Session = Depends(get_db)):
+    user = crud.authenticate_user(db, form_data.username, form_data.password)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Incorrect username or password")
+    access_token = create_access_token({"sub": user.username})
+    return {"access_token": access_token, "token_type": "bearer"}
+
+
 @app.post("/shorten", response_model=schemas.URLInfo)
-def create_short_url(payload: schemas.URLBase, request: Request, db: Session = Depends(get_db)):
-    db_url = crud.get_or_create_short_url(db, original_url=payload.original_url)
+def create_short_url(payload: schemas.URLBase, request: Request, db: Session = Depends(get_db), current_user: models.User = Depends(get_current_user)):
+    db_url = crud.get_or_create_short_url(db, original_url=payload.original_url, owner_id=current_user.id)
     short_url = f"{request.base_url}{db_url.short_code}"
     return {
         "original_url": db_url.original_url,
         "short_url": short_url,
-        "clicks": db_url.clicks
+        "clicks": db_url.clicks,
     }
 
-from fastapi.responses import RedirectResponse
 
 @app.get("/{short_code}")
 def redirect_to_url(short_code: str, db: Session = Depends(get_db)):
     db_url = crud.get_url_by_code(db, short_code)
     if db_url:
-        db_url.clicks += 1
-        db.commit()
+        crud.log_click(db, db_url)
         return RedirectResponse(url=db_url.original_url)
     raise HTTPException(status_code=404, detail="URL not found")
+
+
 @app.get("/analytics/{short_code}")
-def analytics(short_code: str, db: Session = Depends(get_db)):
+def analytics(short_code: str, db: Session = Depends(get_db), current_user: models.User = Depends(get_current_user)):
     db_url = crud.get_url_by_code(db, short_code)
-    if db_url:
-        return {
-            "original_url": db_url.original_url,
-            "short_code": db_url.short_code,
-            "clicks": db_url.clicks,
-            "created_at": db_url.created_at
+    if not db_url:
+        raise HTTPException(status_code=404, detail="Short URL not found")
+    if db_url.owner_id != current_user.id and not current_user.is_admin:
+        raise HTTPException(status_code=403, detail="Not authorized to view analytics")
+    return {
+        "original_url": db_url.original_url,
+        "short_code": db_url.short_code,
+        "clicks": db_url.clicks,
+        "created_at": db_url.created_at,
+    }
+
+
+@app.get("/admin/analytics")
+def all_analytics(db: Session = Depends(get_db), admin_user: models.User = Depends(get_current_admin)):
+    urls = db.query(models.URL).all()
+    return [
+        {
+            "original_url": u.original_url,
+            "short_code": u.short_code,
+            "clicks": u.clicks,
+            "created_at": u.created_at,
         }
-    raise HTTPException(status_code=404, detail="Short URL not found")
+        for u in urls
+    ]
 

--- a/models.py
+++ b/models.py
@@ -1,7 +1,19 @@
 # models.py
-from sqlalchemy import Column, Integer, String, DateTime
+from sqlalchemy import Column, Integer, String, DateTime, Boolean, ForeignKey
+from sqlalchemy.orm import relationship
 from datetime import datetime
 from database import Base
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String, unique=True, index=True)
+    hashed_password = Column(String, nullable=False)
+    is_admin = Column(Boolean, default=False)
+
+    urls = relationship("URL", back_populates="owner")
 
 class URL(Base):
     __tablename__ = "urls"
@@ -11,4 +23,18 @@ class URL(Base):
     short_code = Column(String, unique=True, index=True)
     created_at = Column(DateTime, default=datetime.utcnow)
     clicks = Column(Integer, default=0)
+    owner_id = Column(Integer, ForeignKey("users.id"))
+
+    owner = relationship("User", back_populates="urls")
+    click_logs = relationship("ClickLog", back_populates="url")
+
+
+class ClickLog(Base):
+    __tablename__ = "clicklogs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    url_id = Column(Integer, ForeignKey("urls.id"))
+    timestamp = Column(DateTime, default=datetime.utcnow)
+
+    url = relationship("URL", back_populates="click_logs")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,6 @@ starlette==0.46.2
 typing-inspection==0.4.1
 typing_extensions==4.13.2
 uvicorn==0.34.3
+python-jose==3.3.0
+passlib[bcrypt]==1.7.4
+python-multipart==0.0.9

--- a/schemas.py
+++ b/schemas.py
@@ -1,8 +1,18 @@
 # schemas.py
-from pydantic import BaseModel
+from pydantic import BaseModel, HttpUrl, constr
+
+
+class UserCreate(BaseModel):
+    username: constr(min_length=3)
+    password: constr(min_length=5)
+
+
+class Token(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
 
 class URLBase(BaseModel):
-    original_url: str
+    original_url: HttpUrl
 
 class URLInfo(URLBase):
     short_url: str

--- a/start.sh
+++ b/start.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-uvicorn main:app --host=0.0.0.0 --port=10000
+uvicorn main:app --host=0.0.0.0 --port=8000
 


### PR DESCRIPTION
## Summary
- log URL clicks in a new table
- manage users with hashed passwords and admin flag
- issue JWT tokens for authentication
- restrict analytics routes by user or admin
- add Dockerfile and README
- expose uvicorn on port 8000

## Testing
- `python -m py_compile main.py crud.py models.py schemas.py database.py`

------
https://chatgpt.com/codex/tasks/task_e_68420d8cc2f4832f9ee4ca1a661950f4